### PR TITLE
Provide a custom CA Bundle to enable handling of self-signed SSL certs, or disable SSL verification entirely

### DIFF
--- a/logging_loki/emitter.py
+++ b/logging_loki/emitter.py
@@ -7,7 +7,7 @@ import logging
 import threading
 import time
 from logging.config import ConvertingDict
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import requests
 
@@ -45,7 +45,8 @@ class LokiEmitter:
         as_json: bool = False,
         props_to_labels: Optional[list[str]] = None,
         level_tag: Optional[str] = const.level_tag,
-        logger_tag: Optional[str] = const.logger_tag
+        logger_tag: Optional[str] = const.logger_tag,
+        verify: Union[bool, str] = True
     ):
         """
         Create new Loki emitter.
@@ -72,6 +73,8 @@ class LokiEmitter:
         self.level_tag: str = level_tag
         #: Label name indicating logger name.
         self.logger_tag: str = logger_tag
+        # verify param to be past to requests, can be a bool (to enable/disable SSL verification) or a path to a CA bundle
+        self.verify = verify
 
         self._session: Optional[requests.Session] = None
         self._lock = threading.Lock()
@@ -95,6 +98,7 @@ class LokiEmitter:
         if self._session is None:
             self._session = self.session_class()
             self._session.auth = self.auth or None
+            self._session.verify = self.verify
         return self._session
 
     def close(self):

--- a/logging_loki/handlers.py
+++ b/logging_loki/handlers.py
@@ -70,7 +70,8 @@ class LokiHandler(logging.Handler):
         as_json: Optional[bool] = False,
         props_to_labels: Optional[list[str]] = None,
         level_tag: Optional[str] = const.level_tag,
-        logger_tag: Optional[str] = const.logger_tag
+        logger_tag: Optional[str] = const.logger_tag,
+        verify: Union[bool, str] = True
     ):
         """
         Create new Loki logging handler.
@@ -84,10 +85,11 @@ class LokiHandler(logging.Handler):
             props_to_labels: List of properties that should be converted to loki labels.
             level_tag: Label name indicating logging level.
             logger_tag: Label name indicating logger name.
+            verify: Either a boolean, in which case it controls whether we verify the server's TLS certificate, or a string, in which case it must be a path to a CA bundle to use.
 
         """
         super().__init__()
-        self.emitter = LokiEmitter(url, tags, headers, auth, as_json, props_to_labels, level_tag, logger_tag)
+        self.emitter = LokiEmitter(url, tags, headers, auth, as_json, props_to_labels, level_tag, logger_tag, verify)
 
     def handleError(self, exc: Exception):  # noqa: N802
         """Close emitter and let default handler take actions on error."""


### PR DESCRIPTION
This seems to be the most active fork of the original (abandoned) project.

Our loki server is fronted by an SSL enabled nginx proxy, with a self managed SSL certificate.  We needed to be to provide our own CA bundle to the requests library that could verify the connection without raising an SSL exception, so this PR accomplishes that with minimal impact.

The requests library accepts a verify parameter than can either be a bool (to enable / disable verification) or a string that is treated as a file path to a custom CA bundle to use for verification.

We simple extended this to the LokiHandler.

See the request lib for more details.

https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification

